### PR TITLE
Switch to new emergency create endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medrunner/api-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medrunner/api-client",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "GNU General Public License v3.0",
       "dependencies": {
         "@microsoft/signalr": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medrunner/api-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Wrapper library for the Medrunner API",
   "scripts": {
     "build": "tsup",

--- a/src/api/endpoints/emergency/EmergencyEndpoint.ts
+++ b/src/api/endpoints/emergency/EmergencyEndpoint.ts
@@ -50,7 +50,7 @@ export default class EmergencyEndpoint extends ApiEndpoint {
    * @virtual
    * */
   public async createEmergency(newEmergency: CreateEmergencyRequest): Promise<ApiResponse<Emergency>> {
-    return await this.postRequest<Emergency>("create", newEmergency);
+    return await this.postRequest<Emergency>("", newEmergency);
   }
 
   /**


### PR DESCRIPTION
`/emergency/create` was deprecated in August 2023.