### PR TITLE
Improved reconnect strategy for WS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@medrunner/api-client",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@medrunner/api-client",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "GNU General Public License v3.0",
       "dependencies": {
         "@microsoft/signalr": "^8.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medrunner/api-client",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Wrapper library for the Medrunner API",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Improved reconnect strategy in signalR.
Made first reconnect attempt faster and added variable delay with each attempt with a max of 5 seconds of delay.
Went from 5 reconnect attempt to 10.

Made accessTokenFactory mandatory even when using cookieAuth