### PR TITLE
Refactored timestamps

### DIFF
--- a/src/models/ApiToken.ts
+++ b/src/models/ApiToken.ts
@@ -12,9 +12,9 @@ export default interface ApiToken extends DbItem {
   name: string;
 
   /**
-   * The timestamp at which the token will expire in Unix seconds
+   * The date at which the token will expire
    * */
-  expirationDate?: number;
+  expirationDate?: string;
 
   /**
    *  When the token was last used to generate a new access token, iso-8601 timestamp

--- a/src/models/ChatMessage.ts
+++ b/src/models/ChatMessage.ts
@@ -12,11 +12,6 @@ export default interface ChatMessage extends WritableDbItem {
   senderId: string;
 
   /**
-   * The timestamp at which the message was sent in Unix seconds
-   * */
-  messageSentTimestamp: number;
-
-  /**
    * The contents of the message
    * */
   contents: string;

--- a/src/models/ClientHistory.ts
+++ b/src/models/ClientHistory.ts
@@ -3,5 +3,4 @@ import DbItem from "./DbItem";
 export default interface ClientHistory extends DbItem {
   emergencyId: string;
   clientId: string;
-  emergencyCreationTimestamp: string;
 }

--- a/src/models/Emergency.ts
+++ b/src/models/Emergency.ts
@@ -23,9 +23,8 @@ export default interface Emergency extends WritableDbItem {
   afterActionReportMessage?: DiscordMessage;
   respondingTeam: Team;
   respondingTeams: RespondingTeam[];
-  creationTimestamp: number;
-  acceptedTimestamp?: number;
-  completionTimestamp?: number;
+  acceptedOn?: string;
+  completedOn?: string;
   rating: ResponseRating;
   ratingRemarks?: string;
   origin: Origin;


### PR DESCRIPTION
- Removed unneeded timestamps where we can just use the `created` timestamp of the interfaces
- Changed last unix timestamps to string dates